### PR TITLE
Fix wallet address parsing in addresses api v0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
-    "@dialectlabs/web3": "^0.3.2",
     "@dialectlabs/sdk": "^0.2.0",
+    "@dialectlabs/web3": "^0.3.2",
     "@nestjs/common": "^8.0.0",
     "@nestjs/config": "^2.0.0",
     "@nestjs/core": "^8.0.0",
@@ -54,6 +54,7 @@
     "@nestjs/cli": "^8.0.0",
     "@nestjs/schematics": "^8.0.0",
     "@nestjs/testing": "^8.0.0",
+    "@types/bn.js": "^5.1.0",
     "@types/bs58": "^4.0.1",
     "@types/bytebuffer": "^5.0.43",
     "@types/ed2curve": "^0.2.2",

--- a/src/wallet/wallet.controller.v0.dto.ts
+++ b/src/wallet/wallet.controller.v0.dto.ts
@@ -1,10 +1,4 @@
-import {
-  IsBoolean,
-  IsIn,
-  IsNotEmpty,
-  IsOptional,
-  IsString,
-} from 'class-validator';
+import { IsBoolean, IsIn, IsNotEmpty, IsOptional } from 'class-validator';
 
 // Addresses
 
@@ -36,7 +30,7 @@ export class PutDappAddressDto {
       - enabled
     */
   readonly addressId!: string;
-  @IsString() // TODO: Support custom constraint https://stackoverflow.com/a/53786899/2322073
+  // Switch to wallets api v1, @IsString() validation is removed to fix serde issue from https://github.com/dialectlabs/react/commit/9f87c0b0f398c3a7445ee49aeab2cbd5b6799141#diff-3cbf26f557fe89acc9b185b50a40e3dd7c54feafbfe7e1cd8f3bafd35a870b08R60
   @IsOptional()
   readonly value!: string;
   @IsNotEmpty()

--- a/yarn.lock
+++ b/yarn.lock
@@ -1041,6 +1041,13 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/bn.js@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-5.1.0.tgz#32c5d271503a12653c62cf4d2b45e6eab8cebc68"
+  integrity sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/body-parser@*":
   version "1.19.2"
   resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.2.tgz#aea2059e28b7658639081347ac4fab3de166e6f0"


### PR DESCRIPTION
This resolves issue reported by one of our partners 
Here's the actual reason: https://github.com/dialectlabs/react/commit/9f87c0b0f398c3a7445ee49aeab2cbd5b6799141#diff-3cbf26f557fe89acc9b185b50a40e3dd7c54feafbfe7e1cd8f3bafd35a870b08R60, toBase58() conversion is not done explicitly, therefore sometimes we get json on server side for old clients (but expect string)

Fixing here instead of fixing react lib, since
1. Issue doesn't exist in newest version
2. Saving efforts to update old clients